### PR TITLE
Add Lombok and WebClient dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
         <dependency>
@@ -320,6 +324,11 @@
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -494,6 +503,10 @@
                             <path>
                                 <groupId>org.springframework.boot</groupId>
                                 <artifactId>spring-boot-configuration-processor</artifactId>
+                            </path>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
                             </path>
                             <path>
                                 <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
## Summary
- add the Spring WebFlux starter to enable WebClient usage alongside the existing web stack
- add the Lombok dependency so its annotations can be used within the project
- register Lombok on the Maven compiler annotation processor path so its generated code is available at compile time

## Testing
- mvn -DskipTests compile *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c9752ab0dc832ba843036546d3b082