### PR TITLE
Refactor DTOs to use Lombok

### DIFF
--- a/src/main/java/com/poke/app/service/dto/AdminUserDTO.java
+++ b/src/main/java/com/poke/app/service/dto/AdminUserDTO.java
@@ -8,10 +8,18 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO representing a user, with his authorities.
  */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
 public class AdminUserDTO implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -51,10 +59,6 @@ public class AdminUserDTO implements Serializable {
 
     private Set<String> authorities;
 
-    public AdminUserDTO() {
-        // Empty constructor needed for Jackson.
-    }
-
     public AdminUserDTO(User user) {
         this.id = user.getId();
         this.login = user.getLogin();
@@ -69,128 +73,5 @@ public class AdminUserDTO implements Serializable {
         this.lastModifiedBy = user.getLastModifiedBy();
         this.lastModifiedDate = user.getLastModifiedDate();
         this.authorities = user.getAuthorities().stream().map(Authority::getName).collect(Collectors.toSet());
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getLogin() {
-        return login;
-    }
-
-    public void setLogin(String login) {
-        this.login = login;
-    }
-
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
-
-    public boolean isActivated() {
-        return activated;
-    }
-
-    public void setActivated(boolean activated) {
-        this.activated = activated;
-    }
-
-    public String getLangKey() {
-        return langKey;
-    }
-
-    public void setLangKey(String langKey) {
-        this.langKey = langKey;
-    }
-
-    public String getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(String createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    public Instant getCreatedDate() {
-        return createdDate;
-    }
-
-    public void setCreatedDate(Instant createdDate) {
-        this.createdDate = createdDate;
-    }
-
-    public String getLastModifiedBy() {
-        return lastModifiedBy;
-    }
-
-    public void setLastModifiedBy(String lastModifiedBy) {
-        this.lastModifiedBy = lastModifiedBy;
-    }
-
-    public Instant getLastModifiedDate() {
-        return lastModifiedDate;
-    }
-
-    public void setLastModifiedDate(Instant lastModifiedDate) {
-        this.lastModifiedDate = lastModifiedDate;
-    }
-
-    public Set<String> getAuthorities() {
-        return authorities;
-    }
-
-    public void setAuthorities(Set<String> authorities) {
-        this.authorities = authorities;
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "AdminUserDTO{" +
-            "login='" + login + '\'' +
-            ", firstName='" + firstName + '\'' +
-            ", lastName='" + lastName + '\'' +
-            ", email='" + email + '\'' +
-            ", imageUrl='" + imageUrl + '\'' +
-            ", activated=" + activated +
-            ", langKey='" + langKey + '\'' +
-            ", createdBy=" + createdBy +
-            ", createdDate=" + createdDate +
-            ", lastModifiedBy='" + lastModifiedBy + '\'' +
-            ", lastModifiedDate=" + lastModifiedDate +
-            ", authorities=" + authorities +
-            "}";
     }
 }

--- a/src/main/java/com/poke/app/service/dto/CardDTO.java
+++ b/src/main/java/com/poke/app/service/dto/CardDTO.java
@@ -2,12 +2,19 @@ package com.poke.app.service.dto;
 
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.Card} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CardDTO implements Serializable {
 
     private Long id;
@@ -36,130 +43,8 @@ public class CardDTO implements Serializable {
 
     private CardSetDTO set;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getTcgId() {
-        return tcgId;
-    }
-
-    public void setTcgId(String tcgId) {
-        this.tcgId = tcgId;
-    }
-
-    public String getSetCode() {
-        return setCode;
-    }
-
-    public void setSetCode(String setCode) {
-        this.setCode = setCode;
-    }
-
-    public String getNumber() {
-        return number;
-    }
-
-    public void setNumber(String number) {
-        this.number = number;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getRarity() {
-        return rarity;
-    }
-
-    public void setRarity(String rarity) {
-        this.rarity = rarity;
-    }
-
-    public String getSuperType() {
-        return superType;
-    }
-
-    public void setSuperType(String superType) {
-        this.superType = superType;
-    }
-
-    public String getTypes() {
-        return types;
-    }
-
-    public void setTypes(String types) {
-        this.types = types;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
-
-    public String getLegalities() {
-        return legalities;
-    }
-
-    public void setLegalities(String legalities) {
-        this.legalities = legalities;
-    }
-
-    public CardSetDTO getSet() {
-        return set;
-    }
-
-    public void setSet(CardSetDTO set) {
-        this.set = set;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CardDTO)) {
-            return false;
-        }
-
-        CardDTO cardDTO = (CardDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, cardDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "CardDTO{" +
-            "id=" + getId() +
-            ", tcgId='" + getTcgId() + "'" +
-            ", setCode='" + getSetCode() + "'" +
-            ", number='" + getNumber() + "'" +
-            ", name='" + getName() + "'" +
-            ", rarity='" + getRarity() + "'" +
-            ", superType='" + getSuperType() + "'" +
-            ", types='" + getTypes() + "'" +
-            ", imageUrl='" + getImageUrl() + "'" +
-            ", legalities='" + getLegalities() + "'" +
-            ", set=" + getSet() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/CardSetDTO.java
+++ b/src/main/java/com/poke/app/service/dto/CardSetDTO.java
@@ -3,12 +3,19 @@ package com.poke.app.service.dto;
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.CardSet} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CardSetDTO implements Serializable {
 
     private Long id;
@@ -21,67 +28,8 @@ public class CardSetDTO implements Serializable {
 
     private Instant releaseDate;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Instant getReleaseDate() {
-        return releaseDate;
-    }
-
-    public void setReleaseDate(Instant releaseDate) {
-        this.releaseDate = releaseDate;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CardSetDTO)) {
-            return false;
-        }
-
-        CardSetDTO cardSetDTO = (CardSetDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, cardSetDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "CardSetDTO{" +
-            "id=" + getId() +
-            ", code='" + getCode() + "'" +
-            ", name='" + getName() + "'" +
-            ", releaseDate='" + getReleaseDate() + "'" +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/InventoryItemDTO.java
+++ b/src/main/java/com/poke/app/service/dto/InventoryItemDTO.java
@@ -5,12 +5,19 @@ import com.poke.app.domain.enumeration.CardLanguage;
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.InventoryItem} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class InventoryItemDTO implements Serializable {
 
     private Long id;
@@ -38,121 +45,8 @@ public class InventoryItemDTO implements Serializable {
 
     private PokeUserDTO owner;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Integer getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(Integer quantity) {
-        this.quantity = quantity;
-    }
-
-    public CardCondition getCondition() {
-        return condition;
-    }
-
-    public void setCondition(CardCondition condition) {
-        this.condition = condition;
-    }
-
-    public CardLanguage getLanguage() {
-        return language;
-    }
-
-    public void setLanguage(CardLanguage language) {
-        this.language = language;
-    }
-
-    public Boolean getGraded() {
-        return graded;
-    }
-
-    public void setGraded(Boolean graded) {
-        this.graded = graded;
-    }
-
-    public String getGrade() {
-        return grade;
-    }
-
-    public void setGrade(String grade) {
-        this.grade = grade;
-    }
-
-    public BigDecimal getPurchasePrice() {
-        return purchasePrice;
-    }
-
-    public void setPurchasePrice(BigDecimal purchasePrice) {
-        this.purchasePrice = purchasePrice;
-    }
-
-    public String getNotes() {
-        return notes;
-    }
-
-    public void setNotes(String notes) {
-        this.notes = notes;
-    }
-
-    public CardDTO getCard() {
-        return card;
-    }
-
-    public void setCard(CardDTO card) {
-        this.card = card;
-    }
-
-    public PokeUserDTO getOwner() {
-        return owner;
-    }
-
-    public void setOwner(PokeUserDTO owner) {
-        this.owner = owner;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof InventoryItemDTO)) {
-            return false;
-        }
-
-        InventoryItemDTO inventoryItemDTO = (InventoryItemDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, inventoryItemDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "InventoryItemDTO{" +
-            "id=" + getId() +
-            ", quantity=" + getQuantity() +
-            ", condition='" + getCondition() + "'" +
-            ", language='" + getLanguage() + "'" +
-            ", graded='" + getGraded() + "'" +
-            ", grade='" + getGrade() + "'" +
-            ", purchasePrice=" + getPurchasePrice() +
-            ", notes='" + getNotes() + "'" +
-            ", card=" + getCard() +
-            ", owner=" + getOwner() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/MarketPriceDTO.java
+++ b/src/main/java/com/poke/app/service/dto/MarketPriceDTO.java
@@ -5,12 +5,19 @@ import jakarta.validation.constraints.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.MarketPrice} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class MarketPriceDTO implements Serializable {
 
     private Long id;
@@ -32,103 +39,8 @@ public class MarketPriceDTO implements Serializable {
 
     private CardDTO card;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public MarketSource getSource() {
-        return source;
-    }
-
-    public void setSource(MarketSource source) {
-        this.source = source;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public void setCurrency(String currency) {
-        this.currency = currency;
-    }
-
-    public BigDecimal getPriceLow() {
-        return priceLow;
-    }
-
-    public void setPriceLow(BigDecimal priceLow) {
-        this.priceLow = priceLow;
-    }
-
-    public BigDecimal getPriceMid() {
-        return priceMid;
-    }
-
-    public void setPriceMid(BigDecimal priceMid) {
-        this.priceMid = priceMid;
-    }
-
-    public BigDecimal getPriceHigh() {
-        return priceHigh;
-    }
-
-    public void setPriceHigh(BigDecimal priceHigh) {
-        this.priceHigh = priceHigh;
-    }
-
-    public Instant getLastUpdated() {
-        return lastUpdated;
-    }
-
-    public void setLastUpdated(Instant lastUpdated) {
-        this.lastUpdated = lastUpdated;
-    }
-
-    public CardDTO getCard() {
-        return card;
-    }
-
-    public void setCard(CardDTO card) {
-        this.card = card;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof MarketPriceDTO)) {
-            return false;
-        }
-
-        MarketPriceDTO marketPriceDTO = (MarketPriceDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, marketPriceDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "MarketPriceDTO{" +
-            "id=" + getId() +
-            ", source='" + getSource() + "'" +
-            ", currency='" + getCurrency() + "'" +
-            ", priceLow=" + getPriceLow() +
-            ", priceMid=" + getPriceMid() +
-            ", priceHigh=" + getPriceHigh() +
-            ", lastUpdated='" + getLastUpdated() + "'" +
-            ", card=" + getCard() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/NotificationDTO.java
+++ b/src/main/java/com/poke/app/service/dto/NotificationDTO.java
@@ -5,12 +5,19 @@ import jakarta.persistence.Lob;
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.Notification} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class NotificationDTO implements Serializable {
 
     private Long id;
@@ -34,103 +41,8 @@ public class NotificationDTO implements Serializable {
 
     private UserDTO recipient;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public NotificationType getType() {
-        return type;
-    }
-
-    public void setType(NotificationType type) {
-        this.type = type;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public Boolean getRead() {
-        return read;
-    }
-
-    public void setRead(Boolean read) {
-        this.read = read;
-    }
-
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Instant createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public String getLinkUrl() {
-        return linkUrl;
-    }
-
-    public void setLinkUrl(String linkUrl) {
-        this.linkUrl = linkUrl;
-    }
-
-    public UserDTO getRecipient() {
-        return recipient;
-    }
-
-    public void setRecipient(UserDTO recipient) {
-        this.recipient = recipient;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof NotificationDTO)) {
-            return false;
-        }
-
-        NotificationDTO notificationDTO = (NotificationDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, notificationDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "NotificationDTO{" +
-            "id=" + getId() +
-            ", type='" + getType() + "'" +
-            ", title='" + getTitle() + "'" +
-            ", message='" + getMessage() + "'" +
-            ", read='" + getRead() + "'" +
-            ", createdAt='" + getCreatedAt() + "'" +
-            ", linkUrl='" + getLinkUrl() + "'" +
-            ", recipient=" + getRecipient() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
+++ b/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
@@ -1,39 +1,24 @@
 package com.poke.app.service.dto;
 
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO representing a password change required data - current and new password.
  */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class PasswordChangeDTO implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     private String currentPassword;
     private String newPassword;
-
-    public PasswordChangeDTO() {
-        // Empty constructor needed for Jackson.
-    }
-
-    public PasswordChangeDTO(String currentPassword, String newPassword) {
-        this.currentPassword = currentPassword;
-        this.newPassword = newPassword;
-    }
-
-    public String getCurrentPassword() {
-        return currentPassword;
-    }
-
-    public void setCurrentPassword(String currentPassword) {
-        this.currentPassword = currentPassword;
-    }
-
-    public String getNewPassword() {
-        return newPassword;
-    }
-
-    public void setNewPassword(String newPassword) {
-        this.newPassword = newPassword;
-    }
 }

--- a/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
+++ b/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
@@ -5,14 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 /**
  * A DTO representing a password change required data - current and new password.
  */
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class PasswordChangeDTO implements Serializable {

--- a/src/main/java/com/poke/app/service/dto/PokeUserDTO.java
+++ b/src/main/java/com/poke/app/service/dto/PokeUserDTO.java
@@ -2,12 +2,19 @@ package com.poke.app.service.dto;
 
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.PokeUser} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class PokeUserDTO implements Serializable {
 
     private Long id;
@@ -19,67 +26,8 @@ public class PokeUserDTO implements Serializable {
 
     private UserDTO user;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    public void setCountry(String country) {
-        this.country = country;
-    }
-
-    public UserDTO getUser() {
-        return user;
-    }
-
-    public void setUser(UserDTO user) {
-        this.user = user;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof PokeUserDTO)) {
-            return false;
-        }
-
-        PokeUserDTO pokeUserDTO = (PokeUserDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, pokeUserDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "PokeUserDTO{" +
-            "id=" + getId() +
-            ", displayName='" + getDisplayName() + "'" +
-            ", country='" + getCountry() + "'" +
-            ", user=" + getUser() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/TradeDTO.java
+++ b/src/main/java/com/poke/app/service/dto/TradeDTO.java
@@ -4,12 +4,19 @@ import com.poke.app.domain.enumeration.TradeStatus;
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.Trade} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TradeDTO implements Serializable {
 
     private Long id;
@@ -26,85 +33,8 @@ public class TradeDTO implements Serializable {
 
     private PokeUserDTO proposer;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public TradeStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(TradeStatus status) {
-        this.status = status;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Instant createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Instant getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Instant updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public PokeUserDTO getProposer() {
-        return proposer;
-    }
-
-    public void setProposer(PokeUserDTO proposer) {
-        this.proposer = proposer;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TradeDTO)) {
-            return false;
-        }
-
-        TradeDTO tradeDTO = (TradeDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, tradeDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "TradeDTO{" +
-            "id=" + getId() +
-            ", status='" + getStatus() + "'" +
-            ", message='" + getMessage() + "'" +
-            ", createdAt='" + getCreatedAt() + "'" +
-            ", updatedAt='" + getUpdatedAt() + "'" +
-            ", proposer=" + getProposer() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/TradeItemDTO.java
+++ b/src/main/java/com/poke/app/service/dto/TradeItemDTO.java
@@ -2,12 +2,19 @@ package com.poke.app.service.dto;
 
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.TradeItem} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TradeItemDTO implements Serializable {
 
     private Long id;
@@ -23,76 +30,8 @@ public class TradeItemDTO implements Serializable {
 
     private CardDTO card;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Integer getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(Integer quantity) {
-        this.quantity = quantity;
-    }
-
-    public String getSide() {
-        return side;
-    }
-
-    public void setSide(String side) {
-        this.side = side;
-    }
-
-    public TradeDTO getTrade() {
-        return trade;
-    }
-
-    public void setTrade(TradeDTO trade) {
-        this.trade = trade;
-    }
-
-    public CardDTO getCard() {
-        return card;
-    }
-
-    public void setCard(CardDTO card) {
-        this.card = card;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TradeItemDTO)) {
-            return false;
-        }
-
-        TradeItemDTO tradeItemDTO = (TradeItemDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, tradeItemDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "TradeItemDTO{" +
-            "id=" + getId() +
-            ", quantity=" + getQuantity() +
-            ", side='" + getSide() + "'" +
-            ", trade=" + getTrade() +
-            ", card=" + getCard() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/UserDTO.java
+++ b/src/main/java/com/poke/app/service/dto/UserDTO.java
@@ -2,11 +2,20 @@ package com.poke.app.service.dto;
 
 import com.poke.app.domain.User;
 import java.io.Serializable;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO representing a user, with only the public attributes.
  */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
 public class UserDTO implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -15,60 +24,19 @@ public class UserDTO implements Serializable {
 
     private String login;
 
-    public UserDTO() {
-        // Empty constructor needed for Jackson.
-    }
-
     public UserDTO(User user) {
         this.id = user.getId();
         // Customize it here if you need, or not, firstName/lastName/etc
         this.login = user.getLogin();
     }
 
-    public Long getId() {
-        return id;
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getLogin() {
-        return login;
-    }
-
-    public void setLogin(String login) {
-        this.login = login;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        UserDTO userDTO = (UserDTO) o;
-        if (userDTO.getId() == null || getId() == null) {
-            return false;
-        }
-
-        return Objects.equals(getId(), userDTO.getId()) && Objects.equals(getLogin(), userDTO.getLogin());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId(), getLogin());
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "UserDTO{" +
-            "id='" + id + '\'' +
-            ", login='" + login + '\'' +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object loginEqualityIdentifier() {
+        return id != null ? login : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/service/dto/UserProfileDTO.java
+++ b/src/main/java/com/poke/app/service/dto/UserProfileDTO.java
@@ -3,12 +3,19 @@ package com.poke.app.service.dto;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.*;
 import java.io.Serializable;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * A DTO for the {@link com.poke.app.domain.UserProfile} entity.
  */
 @SuppressWarnings("common-java:DuplicatedBlocks")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class UserProfileDTO implements Serializable {
 
     private Long id;
@@ -29,102 +36,8 @@ public class UserProfileDTO implements Serializable {
 
     private UserDTO user;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getBio() {
-        return bio;
-    }
-
-    public void setBio(String bio) {
-        this.bio = bio;
-    }
-
-    public String getLocation() {
-        return location;
-    }
-
-    public void setLocation(String location) {
-        this.location = location;
-    }
-
-    public String getFavoriteSet() {
-        return favoriteSet;
-    }
-
-    public void setFavoriteSet(String favoriteSet) {
-        this.favoriteSet = favoriteSet;
-    }
-
-    public String getPlaystyle() {
-        return playstyle;
-    }
-
-    public void setPlaystyle(String playstyle) {
-        this.playstyle = playstyle;
-    }
-
-    public byte[] getAvatar() {
-        return avatar;
-    }
-
-    public void setAvatar(byte[] avatar) {
-        this.avatar = avatar;
-    }
-
-    public String getAvatarContentType() {
-        return avatarContentType;
-    }
-
-    public void setAvatarContentType(String avatarContentType) {
-        this.avatarContentType = avatarContentType;
-    }
-
-    public UserDTO getUser() {
-        return user;
-    }
-
-    public void setUser(UserDTO user) {
-        this.user = user;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof UserProfileDTO)) {
-            return false;
-        }
-
-        UserProfileDTO userProfileDTO = (UserProfileDTO) o;
-        if (this.id == null) {
-            return false;
-        }
-        return Objects.equals(this.id, userProfileDTO.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "UserProfileDTO{" +
-            "id=" + getId() +
-            ", bio='" + getBio() + "'" +
-            ", location='" + getLocation() + "'" +
-            ", favoriteSet='" + getFavoriteSet() + "'" +
-            ", playstyle='" + getPlaystyle() + "'" +
-            ", avatar='" + getAvatar() + "'" +
-            ", user=" + getUser() +
-            "}";
+    @EqualsAndHashCode.Include
+    private Object equalityIdentifier() {
+        return id != null ? id : System.identityHashCode(this);
     }
 }

--- a/src/main/java/com/poke/app/web/websocket/dto/ActivityDTO.java
+++ b/src/main/java/com/poke/app/web/websocket/dto/ActivityDTO.java
@@ -1,10 +1,16 @@
 package com.poke.app.web.websocket.dto;
 
 import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * DTO for storing a user's activity.
  */
+@Getter
+@Setter
+@ToString
 public class ActivityDTO {
 
     private String sessionId;
@@ -16,56 +22,4 @@ public class ActivityDTO {
     private String page;
 
     private Instant time;
-
-    public String getSessionId() {
-        return sessionId;
-    }
-
-    public void setSessionId(String sessionId) {
-        this.sessionId = sessionId;
-    }
-
-    public String getUserLogin() {
-        return userLogin;
-    }
-
-    public void setUserLogin(String userLogin) {
-        this.userLogin = userLogin;
-    }
-
-    public String getIpAddress() {
-        return ipAddress;
-    }
-
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
-    public String getPage() {
-        return page;
-    }
-
-    public void setPage(String page) {
-        this.page = page;
-    }
-
-    public Instant getTime() {
-        return time;
-    }
-
-    public void setTime(Instant time) {
-        this.time = time;
-    }
-
-    // prettier-ignore
-    @Override
-    public String toString() {
-        return "ActivityDTO{" +
-            "sessionId='" + sessionId + '\'' +
-            ", userLogin='" + userLogin + '\'' +
-            ", ipAddress='" + ipAddress + '\'' +
-            ", page='" + page + '\'' +
-            ", time='" + time + '\'' +
-            '}';
-    }
 }


### PR DESCRIPTION
## Summary
- replace manual boilerplate in DTO classes with Lombok annotations
- add equality identifier fallbacks so Lombok-generated equals/hashCode preserve previous semantics
- use Lombok constructors for DTOs that previously exposed explicit ones

## Testing
- mvn -DskipITs package *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c97a9d90e0832bad516f7e4c62a148