### PR TITLE
Annotate serialVersionUID fields with @Serial

### DIFF
--- a/src/main/java/com/poke/app/domain/AbstractAuditingEntity.java
+++ b/src/main/java/com/poke/app/domain/AbstractAuditingEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import org.springframework.data.annotation.CreatedBy;
@@ -21,6 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @JsonIgnoreProperties(value = { "createdBy", "createdDate", "lastModifiedBy", "lastModifiedDate" }, allowGetters = true)
 public abstract class AbstractAuditingEntity<T> implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public abstract T getId();

--- a/src/main/java/com/poke/app/domain/Authority.java
+++ b/src/main/java/com/poke/app/domain/Authority.java
@@ -3,6 +3,7 @@ package com.poke.app.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import org.hibernate.annotations.Cache;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Persistable;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class Authority implements Serializable, Persistable<String> {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @NotNull

--- a/src/main/java/com/poke/app/domain/Card.java
+++ b/src/main/java/com/poke/app/domain/Card.java
@@ -2,6 +2,7 @@ package com.poke.app.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -15,6 +16,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class Card implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/CardSet.java
+++ b/src/main/java/com/poke/app/domain/CardSet.java
@@ -2,6 +2,7 @@ package com.poke.app.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import org.hibernate.annotations.Cache;
@@ -16,6 +17,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class CardSet implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/InventoryItem.java
+++ b/src/main/java/com/poke/app/domain/InventoryItem.java
@@ -5,6 +5,7 @@ import com.poke.app.domain.enumeration.CardCondition;
 import com.poke.app.domain.enumeration.CardLanguage;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import org.hibernate.annotations.Cache;
@@ -19,6 +20,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class InventoryItem implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/MarketPrice.java
+++ b/src/main/java/com/poke/app/domain/MarketPrice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.poke.app.domain.enumeration.MarketSource;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -19,6 +20,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class MarketPrice implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/Notification.java
+++ b/src/main/java/com/poke/app/domain/Notification.java
@@ -3,6 +3,7 @@ package com.poke.app.domain;
 import com.poke.app.domain.enumeration.NotificationType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import org.hibernate.annotations.Cache;
@@ -17,6 +18,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class Notification implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/PokeUser.java
+++ b/src/main/java/com/poke/app/domain/PokeUser.java
@@ -2,6 +2,7 @@ package com.poke.app.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -15,6 +16,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class PokeUser implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/Trade.java
+++ b/src/main/java/com/poke/app/domain/Trade.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.poke.app.domain.enumeration.TradeStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import org.hibernate.annotations.Cache;
@@ -18,6 +19,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class Trade implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/TradeItem.java
+++ b/src/main/java/com/poke/app/domain/TradeItem.java
@@ -3,6 +3,7 @@ package com.poke.app.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -16,6 +17,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class TradeItem implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/User.java
+++ b/src/main/java/com/poke/app/domain/User.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class User extends AbstractAuditingEntity<Long> implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/domain/UserProfile.java
+++ b/src/main/java/com/poke/app/domain/UserProfile.java
@@ -2,6 +2,7 @@ package com.poke.app.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -15,6 +16,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class UserProfile implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id

--- a/src/main/java/com/poke/app/security/UserNotActivatedException.java
+++ b/src/main/java/com/poke/app/security/UserNotActivatedException.java
@@ -1,5 +1,6 @@
 package com.poke.app.security;
 
+import java.io.Serial;
 import org.springframework.security.core.AuthenticationException;
 
 /**
@@ -7,6 +8,7 @@ import org.springframework.security.core.AuthenticationException;
  */
 public class UserNotActivatedException extends AuthenticationException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public UserNotActivatedException(String message) {

--- a/src/main/java/com/poke/app/service/EmailAlreadyUsedException.java
+++ b/src/main/java/com/poke/app/service/EmailAlreadyUsedException.java
@@ -1,7 +1,10 @@
 package com.poke.app.service;
 
+import java.io.Serial;
+
 public class EmailAlreadyUsedException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public EmailAlreadyUsedException() {

--- a/src/main/java/com/poke/app/service/InvalidPasswordException.java
+++ b/src/main/java/com/poke/app/service/InvalidPasswordException.java
@@ -1,7 +1,10 @@
 package com.poke.app.service;
 
+import java.io.Serial;
+
 public class InvalidPasswordException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public InvalidPasswordException() {

--- a/src/main/java/com/poke/app/service/UsernameAlreadyUsedException.java
+++ b/src/main/java/com/poke/app/service/UsernameAlreadyUsedException.java
@@ -1,7 +1,10 @@
 package com.poke.app.service;
 
+import java.io.Serial;
+
 public class UsernameAlreadyUsedException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public UsernameAlreadyUsedException() {

--- a/src/main/java/com/poke/app/service/dto/AdminUserDTO.java
+++ b/src/main/java/com/poke/app/service/dto/AdminUserDTO.java
@@ -4,6 +4,7 @@ import com.poke.app.config.Constants;
 import com.poke.app.domain.Authority;
 import com.poke.app.domain.User;
 import jakarta.validation.constraints.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
@@ -22,6 +23,7 @@ import lombok.ToString;
 @NoArgsConstructor
 public class AdminUserDTO implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private Long id;

--- a/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
+++ b/src/main/java/com/poke/app/service/dto/PasswordChangeDTO.java
@@ -1,5 +1,6 @@
 package com.poke.app.service.dto;
 
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,6 +16,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PasswordChangeDTO implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private String currentPassword;

--- a/src/main/java/com/poke/app/service/dto/UserDTO.java
+++ b/src/main/java/com/poke/app/service/dto/UserDTO.java
@@ -1,6 +1,7 @@
 package com.poke.app.service.dto;
 
 import com.poke.app.domain.User;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import lombok.ToString;
 @NoArgsConstructor
 public class UserDTO implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private Long id;

--- a/src/main/java/com/poke/app/web/rest/errors/BadRequestAlertException.java
+++ b/src/main/java/com/poke/app/web/rest/errors/BadRequestAlertException.java
@@ -1,5 +1,6 @@
 package com.poke.app.web.rest.errors;
 
+import java.io.Serial;
 import java.net.URI;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.ErrorResponseException;
@@ -9,6 +10,7 @@ import tech.jhipster.web.rest.errors.ProblemDetailWithCause.ProblemDetailWithCau
 @SuppressWarnings("java:S110") // Inheritance tree of classes should not be too deep
 public class BadRequestAlertException extends ErrorResponseException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String entityName;

--- a/src/main/java/com/poke/app/web/rest/errors/EmailAlreadyUsedException.java
+++ b/src/main/java/com/poke/app/web/rest/errors/EmailAlreadyUsedException.java
@@ -1,8 +1,11 @@
 package com.poke.app.web.rest.errors;
 
+import java.io.Serial;
+
 @SuppressWarnings("java:S110") // Inheritance tree of classes should not be too deep
 public class EmailAlreadyUsedException extends BadRequestAlertException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public EmailAlreadyUsedException() {

--- a/src/main/java/com/poke/app/web/rest/errors/FieldErrorVM.java
+++ b/src/main/java/com/poke/app/web/rest/errors/FieldErrorVM.java
@@ -1,9 +1,11 @@
 package com.poke.app.web.rest.errors;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class FieldErrorVM implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String objectName;

--- a/src/main/java/com/poke/app/web/rest/errors/InvalidPasswordException.java
+++ b/src/main/java/com/poke/app/web/rest/errors/InvalidPasswordException.java
@@ -1,5 +1,6 @@
 package com.poke.app.web.rest.errors;
 
+import java.io.Serial;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.ErrorResponseException;
 import tech.jhipster.web.rest.errors.ProblemDetailWithCause.ProblemDetailWithCauseBuilder;
@@ -7,6 +8,7 @@ import tech.jhipster.web.rest.errors.ProblemDetailWithCause.ProblemDetailWithCau
 @SuppressWarnings("java:S110") // Inheritance tree of classes should not be too deep
 public class InvalidPasswordException extends ErrorResponseException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public InvalidPasswordException() {

--- a/src/main/java/com/poke/app/web/rest/errors/LoginAlreadyUsedException.java
+++ b/src/main/java/com/poke/app/web/rest/errors/LoginAlreadyUsedException.java
@@ -1,8 +1,11 @@
 package com.poke.app.web.rest.errors;
 
+import java.io.Serial;
+
 @SuppressWarnings("java:S110") // Inheritance tree of classes should not be too deep
 public class LoginAlreadyUsedException extends BadRequestAlertException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public LoginAlreadyUsedException() {

--- a/src/test/java/com/poke/app/repository/timezone/DateTimeWrapper.java
+++ b/src/test/java/com/poke/app/repository/timezone/DateTimeWrapper.java
@@ -1,6 +1,7 @@
 package com.poke.app.repository.timezone;
 
 import jakarta.persistence.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.*;
 import java.util.Objects;
@@ -9,6 +10,7 @@ import java.util.Objects;
 @Table(name = "jhi_date_time_wrapper")
 public class DateTimeWrapper implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Id


### PR DESCRIPTION
## Summary
- import `java.io.Serial` and annotate `serialVersionUID` fields with `@Serial` across the domain and DTO layers so serialization identifiers are explicit.
- extend the same annotation to application exceptions, web error view models, and the timezone test entity for consistent serialization metadata.

## Testing
- bash ./mvnw -ntp -DskipTests compile *(fails: Maven wrapper cannot download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c996b39e74832ba924734f0b18acb0