### PR TITLE
Refine Pokemon TCG connector with Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
             <version>${springdoc-openapi-starter-webmvc-api.version}</version>

--- a/src/main/java/com/poke/app/config/ApplicationProperties.java
+++ b/src/main/java/com/poke/app/config/ApplicationProperties.java
@@ -1,5 +1,7 @@
 package com.poke.app.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -8,29 +10,36 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Properties are configured in the {@code application.yml} file.
  * See {@link tech.jhipster.config.JHipsterProperties} for a good example.
  */
+@Getter
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
 
     private final Liquibase liquibase = new Liquibase();
 
+    private final Market market = new Market();
+
     // jhipster-needle-application-properties-property
-
-    public Liquibase getLiquibase() {
-        return liquibase;
-    }
-
     // jhipster-needle-application-properties-property-getter
 
+    @Getter
+    @Setter
     public static class Liquibase {
 
         private Boolean asyncStart = true;
+    }
 
-        public Boolean getAsyncStart() {
-            return asyncStart;
-        }
+    @Getter
+    public static class Market {
 
-        public void setAsyncStart(Boolean asyncStart) {
-            this.asyncStart = asyncStart;
+        private final PokemonTcg pokemonTcg = new PokemonTcg();
+
+        @Getter
+        @Setter
+        public static class PokemonTcg {
+
+            private String baseUrl;
+
+            private String apiKey;
         }
     }
     // jhipster-needle-application-properties-property-class

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardData.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardData.java
@@ -1,0 +1,29 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PokemonTcgCardData {
+
+    @JsonProperty("tcgplayer")
+    private PokemonTcgTcgplayer tcgplayer;
+
+    public Optional<PokemonTcgPricesDTO> price() {
+        return Optional.ofNullable(tcgplayer).flatMap(PokemonTcgTcgplayer::primaryPrice);
+    }
+
+    public Optional<Instant> updatedAt() {
+        return Optional.ofNullable(tcgplayer).flatMap(PokemonTcgTcgplayer::updatedAtInstant);
+    }
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardPrice.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardPrice.java
@@ -1,0 +1,50 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PokemonTcgCardPrice {
+
+    @JsonProperty("low")
+    private BigDecimal low;
+
+    @JsonProperty("mid")
+    private BigDecimal mid;
+
+    @JsonProperty("high")
+    private BigDecimal high;
+
+    @JsonProperty("market")
+    private BigDecimal market;
+
+    @JsonProperty("directLow")
+    private BigDecimal directLow;
+
+    public boolean hasPrices() {
+        return low != null || mid != null || high != null;
+    }
+
+    public int definedValues() {
+        int count = 0;
+        if (low != null) {
+            count++;
+        }
+        if (mid != null) {
+            count++;
+        }
+        if (high != null) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardResponse.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgCardResponse.java
@@ -1,0 +1,29 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PokemonTcgCardResponse {
+
+    @JsonProperty("data")
+    private PokemonTcgCardData data;
+
+    public Optional<PokemonTcgPricesDTO> price() {
+        return Optional.ofNullable(data).flatMap(PokemonTcgCardData::price);
+    }
+
+    public Optional<Instant> updatedAt() {
+        return Optional.ofNullable(data).flatMap(PokemonTcgCardData::updatedAt);
+    }
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgClient.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgClient.java
@@ -1,0 +1,46 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.poke.app.config.ApplicationProperties;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class PokemonTcgClient {
+
+    static final String API_KEY_HEADER = "X-Api-Key";
+
+    private final WebClient webClient;
+
+    public PokemonTcgClient(ApplicationProperties applicationProperties, WebClient.Builder webClientBuilder) {
+        Assert.notNull(applicationProperties, "applicationProperties must not be null");
+        Assert.notNull(webClientBuilder, "webClientBuilder must not be null");
+
+        var configuration = applicationProperties.getMarket().getPokemonTcg();
+        Assert.notNull(configuration, "Pokemon TCG configuration must not be null");
+        Assert.hasText(configuration.getBaseUrl(), "Pokemon TCG API base url must not be empty");
+
+        String apiKey = Objects.toString(configuration.getApiKey(), "");
+        this.webClient = webClientBuilder.clone().baseUrl(configuration.getBaseUrl()).defaultHeader(API_KEY_HEADER, apiKey).build();
+    }
+
+    public PokemonTcgCardResponse getCardById(String cardId) {
+        Assert.hasText(cardId, "cardId must not be blank");
+        log.debug("Requesting card {} from Pokemon TCG API", cardId);
+        PokemonTcgCardResponse response = webClient
+            .get()
+            .uri(uriBuilder -> uriBuilder.path("/v2/cards/{id}").build(cardId))
+            .retrieve()
+            .bodyToMono(PokemonTcgCardResponse.class)
+            .block();
+        return Objects.requireNonNull(response, "Pokemon TCG API returned an empty body");
+    }
+
+    public Optional<PokemonTcgPricesDTO> getCardPrices(String cardId) {
+        return getCardById(cardId).price();
+    }
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgPriceService.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgPriceService.java
@@ -1,0 +1,48 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.poke.app.domain.enumeration.MarketSource;
+import com.poke.app.service.MarketPriceService;
+import com.poke.app.service.dto.CardDTO;
+import com.poke.app.service.dto.MarketPriceDTO;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PokemonTcgPriceService {
+
+    private final PokemonTcgClient pokemonTcgClient;
+    private final MarketPriceService marketPriceService;
+
+    public Optional<MarketPriceDTO> updateCardPrice(CardDTO card) {
+        Assert.notNull(card, "card must not be null");
+        Assert.hasText(card.getTcgId(), "card must contain a tcgId");
+
+        PokemonTcgCardResponse response = pokemonTcgClient.getCardById(card.getTcgId());
+        Optional<PokemonTcgPricesDTO> optionalPrices = response.price();
+
+        if (optionalPrices.isEmpty()) {
+            log.debug("No Pokemon TCG pricing information available for card {}", card.getTcgId());
+            return Optional.empty();
+        }
+
+        PokemonTcgPricesDTO prices = optionalPrices.orElseThrow();
+        MarketPriceDTO marketPrice = new MarketPriceDTO();
+        marketPrice.setSource(MarketSource.POKEMON_TCG_API);
+        marketPrice.setCurrency(prices.getCurrency());
+        marketPrice.setPriceLow(prices.getLow());
+        marketPrice.setPriceMid(prices.getMid());
+        marketPrice.setPriceHigh(prices.getHigh());
+        marketPrice.setLastUpdated(response.updatedAt().orElseGet(Instant::now));
+        marketPrice.setCard(card);
+
+        MarketPriceDTO saved = marketPriceService.save(marketPrice);
+        log.debug("Saved Pokemon TCG pricing for card {}", card.getTcgId());
+        return Optional.ofNullable(saved);
+    }
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgPricesDTO.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgPricesDTO.java
@@ -1,0 +1,20 @@
+package com.poke.app.service.market.pokemontcg;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PokemonTcgPricesDTO {
+
+    public static final String DEFAULT_CURRENCY = "USD";
+
+    @NonNull
+    private final String currency;
+
+    private final BigDecimal low;
+    private final BigDecimal mid;
+    private final BigDecimal high;
+}

--- a/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgTcgplayer.java
+++ b/src/main/java/com/poke/app/service/market/pokemontcg/PokemonTcgTcgplayer.java
@@ -1,0 +1,63 @@
+package com.poke.app.service.market.pokemontcg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Slf4j
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PokemonTcgTcgplayer {
+
+    private static final DateTimeFormatter UPDATED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+    @JsonProperty("updatedAt")
+    private String updatedAt;
+
+    @JsonProperty("prices")
+    private Map<String, PokemonTcgCardPrice> prices;
+
+    public Optional<Instant> updatedAtInstant() {
+        if (!StringUtils.hasText(updatedAt)) {
+            return Optional.empty();
+        }
+        try {
+            LocalDate date = LocalDate.parse(updatedAt, UPDATED_AT_FORMATTER);
+            return Optional.of(date.atStartOfDay(ZoneOffset.UTC).toInstant());
+        } catch (DateTimeParseException ex) {
+            log.debug("Unable to parse updatedAt [{}] from Pokemon TCG API", updatedAt, ex);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<PokemonTcgPricesDTO> primaryPrice() {
+        if (prices == null || prices.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return prices
+            .values()
+            .stream()
+            .filter(Objects::nonNull)
+            .filter(PokemonTcgCardPrice::hasPrices)
+            .max(Comparator.comparingInt(PokemonTcgCardPrice::definedValues))
+            .map(price -> new PokemonTcgPricesDTO(PokemonTcgPricesDTO.DEFAULT_CURRENCY, price.getLow(), price.getMid(), price.getHigh()));
+    }
+}

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -104,4 +104,8 @@ jhipster:
 # https://www.jhipster.tech/common-application-properties/
 # ===================================================================
 
-# application:
+application:
+  market:
+    pokemon-tcg:
+      base-url: ${POKEMON_TCG_API_BASE_URL:https://api.pokemontcg.io}
+      api-key: ${POKEMON_TCG_API_KEY:}

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -121,4 +121,8 @@ jhipster:
 # https://www.jhipster.tech/common-application-properties/
 # ===================================================================
 
-# application:
+application:
+  market:
+    pokemon-tcg:
+      base-url: ${POKEMON_TCG_API_BASE_URL:https://api.pokemontcg.io}
+      api-key: ${POKEMON_TCG_API_KEY:}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -226,4 +226,8 @@ jhipster:
 # https://www.jhipster.tech/common-application-properties/
 # ===================================================================
 
-# application:
+application:
+  market:
+    pokemon-tcg:
+      base-url: ${POKEMON_TCG_API_BASE_URL:https://api.pokemontcg.io}
+      api-key: ${POKEMON_TCG_API_KEY:}

--- a/src/test/java/com/poke/app/service/market/pokemontcg/PokemonTcgPriceServiceTest.java
+++ b/src/test/java/com/poke/app/service/market/pokemontcg/PokemonTcgPriceServiceTest.java
@@ -1,0 +1,158 @@
+package com.poke.app.service.market.pokemontcg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.poke.app.config.ApplicationProperties;
+import com.poke.app.domain.enumeration.MarketSource;
+import com.poke.app.service.MarketPriceService;
+import com.poke.app.service.dto.CardDTO;
+import com.poke.app.service.dto.MarketPriceDTO;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class PokemonTcgPriceServiceTest {
+
+    private static final DateTimeFormatter UPDATED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+    @Mock
+    private MarketPriceService marketPriceService;
+
+    private MockWebServer mockWebServer;
+
+    private PokemonTcgPriceService pokemonTcgPriceService;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        ApplicationProperties properties = new ApplicationProperties();
+        properties.getMarket().getPokemonTcg().setBaseUrl(mockWebServer.url("/").toString());
+        properties.getMarket().getPokemonTcg().setApiKey("test-api-key");
+
+        PokemonTcgClient client = new PokemonTcgClient(properties, WebClient.builder());
+        pokemonTcgPriceService = new PokemonTcgPriceService(client, marketPriceService);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void shouldFetchPriceAndPersist() throws Exception {
+        mockWebServer.enqueue(
+            new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "data": {
+                        "tcgplayer": {
+                          "updatedAt": "2024/02/29",
+                          "prices": {
+                            "holofoil": {
+                              "low": 1.10,
+                              "mid": 2.20
+                            },
+                            "normal": {
+                              "low": 1.50,
+                              "mid": 2.50,
+                              "high": 3.50
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """
+                )
+        );
+
+        CardDTO card = createCard();
+
+        when(marketPriceService.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Optional<MarketPriceDTO> result = pokemonTcgPriceService.updateCardPrice(card);
+
+        assertThat(result).isPresent();
+        MarketPriceDTO saved = result.orElseThrow();
+        assertThat(saved.getSource()).isEqualTo(MarketSource.POKEMON_TCG_API);
+        assertThat(saved.getCurrency()).isEqualTo("USD");
+        assertThat(saved.getPriceLow()).isEqualByComparingTo("1.50");
+        assertThat(saved.getPriceMid()).isEqualByComparingTo("2.50");
+        assertThat(saved.getPriceHigh()).isEqualByComparingTo("3.50");
+        assertThat(saved.getCard()).isEqualTo(card);
+
+        Instant expectedInstant = LocalDate.parse("2024/02/29", UPDATED_AT_FORMATTER).atStartOfDay(ZoneOffset.UTC).toInstant();
+        assertThat(saved.getLastUpdated()).isEqualTo(expectedInstant);
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(recordedRequest).isNotNull();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getPath()).isEqualTo("/v2/cards/xy7-54");
+        assertThat(recordedRequest.getHeader(PokemonTcgClient.API_KEY_HEADER)).isEqualTo("test-api-key");
+
+        verify(marketPriceService).save(any());
+    }
+
+    @Test
+    void shouldNotPersistWhenNoPricesPresent() throws Exception {
+        mockWebServer.enqueue(
+            new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "data": {
+                        "tcgplayer": {
+                          "updatedAt": "2024/02/29",
+                          "prices": { }
+                        }
+                      }
+                    }
+                    """
+                )
+        );
+
+        CardDTO card = createCard();
+
+        Optional<MarketPriceDTO> result = pokemonTcgPriceService.updateCardPrice(card);
+
+        assertThat(result).isEmpty();
+        verify(marketPriceService, never()).save(any());
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(recordedRequest).isNotNull();
+        assertThat(recordedRequest.getPath()).isEqualTo("/v2/cards/xy7-54");
+    }
+
+    private static CardDTO createCard() {
+        CardDTO card = new CardDTO();
+        card.setId(123L);
+        card.setTcgId("xy7-54");
+        card.setSetCode("xy7");
+        card.setNumber("54");
+        card.setName("Gardevoir");
+        return card;
+    }
+}


### PR DESCRIPTION
## Summary
- switch the Pokemon TCG configuration properties to Lombok-backed getters/setters to reduce boilerplate
- migrate the connector DTOs, client and service to Lombok annotations while keeping the existing pricing helpers intact

## Testing
- `mvn -ntp test` *(fails: cannot resolve the Spring Boot parent because Maven Central is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dba45d8c832ba8be1730516da673